### PR TITLE
match Stockfighter's language on incoming orders

### DIFF
--- a/disorderBook_book.py
+++ b/disorderBook_book.py
@@ -245,6 +245,9 @@ class OrderBook ():
 	def parse_order(self, info):
 		
 		assert(info["venue"] == self.venue)
+                # Match behavior of real Stockfighter: recognize both `symbol` and `stock`.
+		if "stock" in info:
+			info["symbol"] = info["stock"]
 		assert(info["symbol"] == self.symbol)
 		assert(info["direction"] in ["buy", "sell"])
 		assert(info["qty"] > 0)
@@ -338,6 +341,3 @@ class OrderBook ():
 					bisect.insort(self.asks, order)
 		
 		return order
-	
-	
-		

--- a/disorderBook_main.py
+++ b/disorderBook_main.py
@@ -173,7 +173,12 @@ class StockFighterHandler(http.server.BaseHTTPRequestHandler):
 				data = json.loads(data)
 
 				venue = data["venue"]
-				symbol = data["symbol"]
+
+				# Match behavior of real Stockfighter: recognize both these forms
+				if "stock" in data:
+					symbol = data["stock"]
+				elif "symbol" in data:
+					symbol = data["symbol"]
 			
 				create_book_if_needed(venue, symbol)
 			


### PR DESCRIPTION
The real Stockfighter API recognizes both `stock` and `symbol` as keys
on incoming orders (and possibly other, undiscovered synonyms). However,
the disorder book would recognize only the `symbol` form and emit a
cryptic error (the result of an assertion failure) if the client made
use of the other form. Sadly, `stock` is the form given in the
documentation.

With this change, the disorder book will recognize either form. If both
are present, `stock` silently takes priority.

Fixes #1