### PR TITLE
Add on Z for zulu time to date

### DIFF
--- a/disorderBook_book.py
+++ b/disorderBook_book.py
@@ -24,7 +24,7 @@ EXECUTION_TEMPLATE = '''
 
 
 def current_timestamp():
-    ts = str(datetime.datetime.utcnow().isoformat())        # Thanks to medecau for this
+    ts = str(datetime.datetime.utcnow().isoformat()) + 'Z'       # Thanks to medecau for this
     return ts
 
 


### PR DESCRIPTION
Date times for stockfighter appear to be UTC as all the examples end in
Z. Apparently python violates the standard and even though disorderbook
uses utc now the resulting date string doesn't include the timezone
info.

https://en.wikipedia.org/wiki/ISO_8601#Time_zone_designators
https://starfighter.readme.io/docs/get-orderbook-for-stock